### PR TITLE
Add minute assertion to time signal test

### DIFF
--- a/src/time.rs
+++ b/src/time.rs
@@ -165,6 +165,7 @@ mod tests {
         let (next, sig) = service.compute_next_time();
         assert_eq!(sig, TimeSignal::DataPrep);
         assert_eq!(next.time().hour(), 8);
+        assert_eq!(next.time().minute(), 30);
 
         // 09:00 이후 -> 업데이트
         let now = c.with_ymd_and_hms(2025, 7, 16, 10, 0, 0).unwrap();


### PR DESCRIPTION
## Summary
- ensure `compute_next_time` returns 08:30 for `DataPrep`

## Testing
- `cargo test` *(fails: unable to fetch crates index)*

------
https://chatgpt.com/codex/tasks/task_e_687891144744832c917b97febb9b331c